### PR TITLE
Remove useless promise

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Create a client:
 
 Publish an event to the bus:
 
-    yield client.publish('the-key', message);
+    client.publish('the-key', message);
 
 Use the client to listen to the bus:
 
     yield client.listen('the-queue', 'the-key', (message, callback) => {
-    
+
       // ... process message ...
 
       callback();
@@ -35,7 +35,7 @@ Use the client to listen to the bus:
 If you need to pass additionnal options to AMQP:
 
     yield client.listen('the-queue', 'the-key', options, (message, callback) => {
-    
+
       // ... process message ...
 
       callback();
@@ -44,7 +44,7 @@ If you need to pass additionnal options to AMQP:
 If you want to message to be reinjected in the queue because you failed:
 
     yield client.listen('the-queue', 'the-key', options, (message, callback) => {
-    
+
       // ... process message ...
 
       callback(new Error('Epic fail'));
@@ -52,6 +52,6 @@ If you want to message to be reinjected in the queue because you failed:
 
 ## Developement system dependencies
 
-To run the tests, you need a local RabbitMQ. The simplest way to do this with the 
+To run the tests, you need a local RabbitMQ. The simplest way to do this with the
 exact versions used in production is to use the Dockerfile available here: https://github.com/transcovo/environments-tech/tree/master/docker
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ module.exports.createBusClient = co.wrap(function* createBusClient(url) {
         });
       });
     }),
-    publish: (routingKey, message) => new Promise(resolve =>
-      resolve(channel.publish(EXCHANGE, routingKey, new Buffer(JSON.stringify(message)))))
+    publish: (routingKey, message) => channel.publish(EXCHANGE, routingKey, new Buffer(JSON.stringify(message)))
   };
 });

--- a/index.js
+++ b/index.js
@@ -25,6 +25,6 @@ module.exports.createBusClient = co.wrap(function* createBusClient(url) {
         });
       });
     }),
-    publish: (routingKey, message) => channel.publish(EXCHANGE, routingKey, new Buffer(JSON.stringify(message)))
+    publish: (routingKey, message, options) => channel.publish(EXCHANGE, routingKey, new Buffer(JSON.stringify(message)), options)
   };
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -27,7 +27,7 @@ describe('Node AMQP Bus', function testBus() {
       callback();
     });
 
-    yield client.publish('key', { test: 'message' });
+    client.publish('key', { test: 'message' });
 
     const message1 = yield p1;
     message1.should.eql({ test: 'message' });
@@ -55,7 +55,7 @@ describe('Node AMQP Bus', function testBus() {
       callback();
     });
 
-    yield client.publish('key', { test: 'message' });
+    client.publish('key', { test: 'message' });
 
     yield Promise.race([p1, p2]);
 
@@ -77,7 +77,7 @@ describe('Node AMQP Bus', function testBus() {
       callback();
     });
 
-    yield client.publish('key', { test: 'message' });
+    client.publish('key', { test: 'message' });
 
     yield p2;
 


### PR DESCRIPTION
#### Remove useless promise. 

When publishing to a channel we don't get any response so it's
useless to return a promise and force the user to write things
such as `yield publish` where publish is an immediatly resolved
promise.

If you want to have a real promise mecanism, you should resolve the promise
once the server has replied that the message has been taken into account
like here: http://www.squaremobius.net/amqp.node/channel_api.html#confirmchannel

#### Add options to publish.

The amqplib lets you pass options when publishing a message,
we should let the user of our lib use those options