### PR TITLE
Add new methods to the client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ Close client
 
 Publish an event to the bus:
 
-    client.publish('the-key', message);
+    client.publish('your-exchange', 'the-key', message);
 
 Use the client to listen to the bus:
 
-    yield client.listen('the-queue', 'the-key', (message, callback) => {
+    yield client.listen('your-exchange', 'the-queue', 'the-key', (message, callback) => {
 
       // ... process message ...
 
@@ -38,7 +38,7 @@ Use the client to listen to the bus:
 
 If you need to pass additionnal options to AMQP:
 
-    yield client.listen('the-queue', 'the-key', options, (message, callback) => {
+    yield client.listen('your-exchange', 'the-queue', 'the-key', options, (message, callback) => {
 
       // ... process message ...
 
@@ -47,7 +47,7 @@ If you need to pass additionnal options to AMQP:
 
 If you want to message to be reinjected in the queue because you failed:
 
-    yield client.listen('the-queue', 'the-key', options, (message, callback) => {
+    yield client.listen('your-exchange', 'the-queue', 'the-key', options, (message, callback) => {
 
       // ... process message ...
 
@@ -61,6 +61,4 @@ You can directly access to the raw connection and channel objects:
 
 ## Developement system dependencies
 
-To run the tests, you need a local RabbitMQ. The simplest way to do this with the
-exact versions used in production is to use the Dockerfile available here: https://github.com/transcovo/environments-tech/tree/master/docker
-
+To run the tests, you need a local RabbitMQ responding on 'amqp://guest:guest@localhost:5672'.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-amqp-bus",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Implement a Bus using AMQP in nodejs",
   "main": "index.js",
   "repository": {
@@ -18,7 +18,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "bluebird": "^3.2.1",
     "co-mocha": "^1.1.2",
     "eslint": "^1.10.3",
     "eslint-config-cp": "github:transcovo/eslint-config-cp#1.0.3",


### PR DESCRIPTION
The main changes are:
- The publish method require an exchange as first argument.
- The listen method require an exchange as first argument. It wraps the
`setupQueue` and `consume` method in a single call
- The close method reset the channel and connection attribute of the
client to `null`
- The setupQueue method (NEW) Check that exchange and queue are created
and bind exchange to queue with rooting key. It let you specify an
exchange type which default to topic.
- The consume method (NEW) pass messages to its handler and handle
acknowledgement of messages.