### PR TITLE
TECH Automatically reconnect on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ You can use `listener` as an EventEmitter. It emits the following events =
   - `connect()` : emitted once, when the first call to listen() is made
   - `handle_error(err, { err, queue, message })` : emitted when a message cannot be consumed
     correctly by the client (not a JSON, handler failed)
+  - `connection_error(err, { err, queue })` : emitted when a message cannot be consumed
+    correctly by the client (not a JSON, handler failed)
 
 ## Client API
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -39,7 +39,6 @@ function* createClient(url, options) {
     }
   });
   yield _connect();
-  _onDisconnection(busClient);
   return busClient;
 
   /**
@@ -139,10 +138,6 @@ function* createClient(url, options) {
    * @return {void}
    */
   function _onDisconnection(err) {
-    // for some reason the on('error') event is called twice
-    // - once with an event emitter (ignored)
-    // - once with an error (what we want)
-    if (err.constructor === EventEmitter) return;
     busClient.emit('connection_error', new Error('Connection failed'), { err });
     setTimeout(_reconnect, options.reconnectTimeout);
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -7,6 +7,7 @@ const co = require('co');
 
 const DEFAULT_EXCHANGE_TYPE = 'topic';
 const DEFAULT_HEARTBEAT = 10;
+const DEFAULT_RECONNECT_TIMEOUT = 1000;
 
 /**
  * Return a bus client with helper methods to communicate with an amqp server.
@@ -14,27 +15,31 @@ const DEFAULT_HEARTBEAT = 10;
  * @name  createClient.
  * @param {String} url : The url of your amqp server.
  * @param {Object} [options]
- * @param {Number} [options.heartbeat] : the heartbeat that you want to use.
+ * @param {Number} [options.heartbeat=10] : the heartbeat that you want to use.
+ * @param {Number} [options.reconnectTimeout=1000] : delay to reconnect broken connections
  */
 function* createClient(url, options) {
   options = options || {};
   options.heartbeat = options.heartbeat || DEFAULT_HEARTBEAT;
-  const connection = yield amqplib.connect(url, options);
-  const channel = yield connection.createChannel();
+  options.reconnectTimeout = options.reconnectTimeout || DEFAULT_RECONNECT_TIMEOUT;
+
+  const _reconnect = co.wrap(_connect);
 
   const busClient = Object.assign(Object.create(EventEmitter.prototype), {
-    channel,
-    connection,
+    connection: null,
+    channel: null,
     setupQueue,
     consume,
     listen,
     publish,
     close: function* close() {
-      yield connection.close();
+      yield this.connection.close();
       this.connection = null;
       this.channel = null;
     }
   });
+  yield _connect();
+  _onDisconnection(busClient);
   return busClient;
 
   /**
@@ -100,7 +105,7 @@ function* createClient(url, options) {
    * @param {String} exchange : the name of the exchange on which you want to connect.
    * @param {String} queue : the queue name
    * @param {String} rootingKey : the rooting that you want to bind.
-  * @param {Function} handler : should be yieldable,
+   * @param {Function} handler : should be yieldable,
    * @param {Object} [opts] : various options that will be passed to the setupQueue method
    */
   function* listen(exchange, queue, rootingKey, handler, opts) {
@@ -119,6 +124,27 @@ function* createClient(url, options) {
    */
   function publish(exchange, rootingKey, message, opts) {
     return busClient.channel.publish(exchange, rootingKey, new Buffer(JSON.stringify(message)), opts);
+  }
+
+  function* _connect() {
+    busClient.connection = yield amqplib.connect(url, options);
+    busClient.channel = yield busClient.connection.createChannel();
+    // see error handling and reconnection https://www.cloudamqp.com/docs/nodejs.html
+    // http://www.squaremobius.net/amqp.node/channel_api.html#failure
+    busClient.connection.on('error', _onDisconnection);
+    busClient.emit('connected');
+  }
+
+  /**
+   * @return {void}
+   */
+  function _onDisconnection(err) {
+    // for some reason the on('error') event is called twice
+    // - once with an event emitter (ignored)
+    // - once with an error (what we want)
+    if (err.constructor === EventEmitter) return;
+    busClient.emit('connection_error', new Error('Connection failed'), { err });
+    setTimeout(_reconnect, options.reconnectTimeout);
   }
 }
 

--- a/lib/listener.js
+++ b/lib/listener.js
@@ -12,6 +12,7 @@ const createClient = require('./client');
  * @param {String} url Bus AMQP url
  * @param {Object} [options] options
  * @param {Object} [options.client] client to use
+ * @param {Number} [options.reconnectTimeout=1000] : delay to reconnect broken connections
  * @return {Object} bus listener instance
  */
 function createListener(url, options) {
@@ -51,10 +52,14 @@ function createListener(url, options) {
    */
   function* listen(exchange, opts) {
     if (instance.client) return;
-    instance.client = options.client || (yield createClient(url));
+    instance.client = options.client || (yield createClient(url, {
+      reconnectTimeout: options.reconnectTimeout
+    }));
     instance.emit('connect');
 
     instance.client.on('consume_error', (err, metadata) => instance.emit('handle_error', err, metadata));
+    instance.client.on('connection_error', (err, metadata) => instance.emit('connection_error', err, metadata));
+    instance.client.on('connected', () => instance.emit('connected'));
 
     for (const queue of queues) {
       for (const key of Object.keys(handlers[queue])) {

--- a/test/lib/client.test.js
+++ b/test/lib/client.test.js
@@ -237,7 +237,7 @@ describe('Node AMQP Bus Client', function testBus() {
         onConnectedSpy.callCount.should.equal(0);
 
         // wait for the reconnectTimeout
-        yield cb => setTimeout(cb, 100);
+        yield cb => setTimeout(cb, 200);
 
         onConnectedSpy.callCount.should.equal(1);
       });


### PR DESCRIPTION
Currently workers using this lib are not resilient to a broken connection with AMQP: the messages are kept unacked and tasks simply stop getting processed.
This PR implements an auto-reconnect logic as described in https://www.cloudamqp.com/docs/nodejs.html and based on this doc http://www.squaremobius.net/amqp.node/channel_api.html#failure