### PR TITLE
TECH Fix typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,11 +14,15 @@ declare class Bus {
   static createClient(url: string, options?: Bus.BusOptions): BusClient;
 }
 
-export class BusClient extends EventEmitter {
-  channel: Channel;
-  connection: Connection;
+export interface BusClient extends EventEmitter {
+  publish(
+    exchange: string,
+    routingKey: string,
+    message: Object,
+    options?: Bus.PublishOptions,
+  ): Boolean;
 
-  publish(exchange: string, routingKey: string, message: Object, options?: Bus.PublishOptions): Boolean;
+  close(): Promise<void>;
 }
 
 declare namespace Bus {

--- a/lib/client.js
+++ b/lib/client.js
@@ -40,11 +40,11 @@ function* createClient(rabbitmqUrl, options) {
     consume,
     listen,
     publish,
-    close: function* close() {
+    close: co.wrap(function* close() {
       yield connection.close();
       this.connection = null;
       this.channel = null;
-    }
+    })
   });
   return busClient;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chauffeur-prive/node-amqp-bus",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Implement a Bus using AMQP in nodejs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
To keep things short, we had an issue with the `BusClient` class type is not a proper class but a js object, so in typescript when we try to create a class that extends `BusClient` we get a very obscure error about the prototype.

`BusClient` is now an interface, allowing to define classes implementing its protocol.

(also co.wrapped the close method to be able to use it with async/await)