### PR TITLE
TRAN-28143 - feat(connection|event): Handling close cleanup operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ You can use `listener` as an EventEmitter. It emits the following events =
 
 ## Client API
 
+### EventEmitter interface
+
+The client is an EventEmitter`. It emits the following events:
+
+* `close_cleanup`: emitted once, when handling a `close` connection event.  
+   It provides a timeout (defaut = `200ms`) before executing a `client.close(forceClose = true)`,  
+   for the host app to execute any cleanup operations (such as closing a `mongodb` client).
+
 ### bus.createClient(url)
 
 Creates a client. Returns a `Promise` of the client.
@@ -61,7 +69,7 @@ Creates a client. Returns a `Promise` of the client.
 
 Closes the client. Returns a `Promise`.
 When passing a truthy `forceClose`, `close()` will also `exit(1)` the current process,
-so when handling erronous case that you can't recover from, one should call `close(true)`.
+so when handling erroneous case that you can't recover from, one should call `close(true)`.
 
     client.close();
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,8 @@ declare namespace Bus {
   export interface BusOptions {
     heartbeat?: number;
     useConfirmChannel?: Boolean;
+    processExitCleanupTimeout?: number;
+    processExitTimeout?: number;
   }
 
   export interface PublishOptions {

--- a/lib/client.js
+++ b/lib/client.js
@@ -20,6 +20,7 @@ const DEFAULT_HEARTBEAT = 10;
  * @param {Object} [options]
  * @param {Number} [options.heartbeat] : the heartbeat that you want to use.
  * @param {Boolean} [options.useConfirmChannel] : use a confirm channel
+ * @param {Number|undefined} [options.processExitCleanupTimeout] : the time in ms that is (at least) waited for close cleanup operations.
  * @param {Number|undefined} [options.processExitTimeout] : the time in ms that is (at least) waited before exiting process.
  */
 function* createClient(rabbitmqUrl, options) {
@@ -29,6 +30,8 @@ function* createClient(rabbitmqUrl, options) {
 
   const parsedurl = url.parse(rabbitmqUrl);
   options.servername = parsedurl.hostname;
+
+  options.processExitCleanupTimeout = options.processExitCleanupTimeout || 200;
   options.processExitTimeout = options.processExitTimeout || 0;
 
   const connection = yield amqplib.connect(rabbitmqUrl, options);
@@ -67,12 +70,20 @@ function* createClient(rabbitmqUrl, options) {
 
   /**
    * Handle the close event from the connection by cleaning amqp resources & exiting the process,
-   * as restart is handled by the instance orchestrator
-   * @returns {Promise<void>} - Returns the client close promise
+   * as restart is handled by the instance orchestrator.
+   * An exit cleanup timeout is provided for the host app to execute some cleanup operations
+   * @returns {void}
    */
   function handleExitOnConnectionClose() {
-    logger.error('[client#handleExitOnConnectionClose] Client connection closed, process will exit');
-    return busClient.close(true);
+    const timeoutClearToken = setTimeout(timeoutHandler, options.processExitCleanupTimeout);
+
+    function timeoutHandler() {
+      clearTimeout(timeoutClearToken);
+      logger.info('[client#handleExitOnConnectionClose] Client connection closed, process will exit');
+      return busClient.close(true);
+    }
+
+    busClient.emit('close_cleanup');
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chauffeur-prive/node-amqp-bus",
-  "version": "5.1.2",
+  "version": "5.2.0",
   "description": "Implement a Bus using AMQP in nodejs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Ticket reference

https://transcovo.atlassian.net/browse/TRAN-28143

## Goal

Continuing from the work done in https://github.com/transcovo/node-amqp-bus/pull/27, we wanted to provide a way for the host app to execute cleanup operations before exiting the process itself.

After experimenting with more or less elaborate ways to do it, we settled on a simple solution:
* Send a `close_cleanup` event from the client => the host app can subscribe to it and implement
  its cleanup operations.

* A simple timeout is defined (default = `200ms`): once reached, the previously implemented `client.close(forceExit = true)` is executed & the process is exited.
     => If the cleanup operations exceed the defined timeout, they won't be executed to completion. 
 

## Related PRs
https://github.com/transcovo/node-amqp-bus/pull/27